### PR TITLE
Implement Flags

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/events/BlockEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/events/BlockEventHandler.java
@@ -200,9 +200,13 @@ public class BlockEventHandler {
                 String noBuildReason = GriefPrevention.instance.allowBreak(player.get(), transaction.getOriginal());
                 Claim claim = this.dataStore.getClaimAt(transaction.getOriginal().getLocation().get(), false, null);
                 if (claim != null) {
-                    if (player.get().getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_BLOCK_BREAK) == Tristate.FALSE) {
+                    Tristate value = player.get().getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_BLOCK_BREAK);
+                    if (value == Tristate.FALSE) {
                         event.setCancelled(true);
                         return;
+                    }
+                    else if (value == Tristate.TRUE) {
+                        continue;
                     }
                 }
                 if (noBuildReason != null) {
@@ -320,9 +324,13 @@ public class BlockEventHandler {
             Claim claim = this.dataStore.getClaimAt(block.getLocation().get(), true, playerData.lastClaim);
 
             if (claim != null) {
-                if (player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_BLOCK_PLACE) == Tristate.FALSE) {
+                Tristate value = player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_BLOCK_PLACE);
+                if (value == Tristate.FALSE) {
                     event.setCancelled(true);
                     return;
+                }
+                else if (value == Tristate.TRUE) {
+                    continue;
                 }
 
                 playerData.lastClaim = claim;

--- a/src/me/ryanhamshire/GriefPrevention/events/EntityEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/events/EntityEventHandler.java
@@ -68,7 +68,6 @@ import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.EntityDamageSource;
 import org.spongepowered.api.event.entity.DamageEntityEvent;
 import org.spongepowered.api.event.entity.DestructEntityEvent;
-import org.spongepowered.api.event.entity.InteractEntityEvent;
 import org.spongepowered.api.event.entity.SpawnEntityEvent;
 import org.spongepowered.api.event.filter.IsCancelled;
 import org.spongepowered.api.event.item.inventory.DropItemEvent;

--- a/src/me/ryanhamshire/GriefPrevention/events/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/events/PlayerEventHandler.java
@@ -24,6 +24,7 @@
  */
 package me.ryanhamshire.GriefPrevention.events;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import me.ryanhamshire.GriefPrevention.AutoExtendClaimTask;
 import me.ryanhamshire.GriefPrevention.CheckForPortalTrapTask;
@@ -33,6 +34,7 @@ import me.ryanhamshire.GriefPrevention.CreateClaimResult;
 import me.ryanhamshire.GriefPrevention.CustomLogEntryTypes;
 import me.ryanhamshire.GriefPrevention.DataStore;
 import me.ryanhamshire.GriefPrevention.EquipShovelProcessingTask;
+import me.ryanhamshire.GriefPrevention.FlagPermissions;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import me.ryanhamshire.GriefPrevention.IpBanInfo;
 import me.ryanhamshire.GriefPrevention.Messages;
@@ -1096,11 +1098,22 @@ public class PlayerEventHandler {
         }
 
         if (event instanceof InteractEntityEvent.Primary) {
+            if (player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_INTERACT_PRIMARY) == Tristate.FALSE) {
+                event.setCancelled(true);
+            }
             if (claim != null && claim.allowAccess(player.getWorld(), player) != null) {
                 event.setCancelled(true);
             }
             return;
         }
+
+        if (event instanceof InteractEntityEvent.Secondary) {
+            if (player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_INTERACT_SECONDARY) == Tristate.FALSE) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+
         // if entity is tameable and has an owner, apply special rules
         if (entity.supports(TameableData.class)) {
             TameableData data = entity.getOrCreate(TameableData.class).get();

--- a/src/me/ryanhamshire/GriefPrevention/events/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/events/PlayerEventHandler.java
@@ -956,6 +956,19 @@ public class PlayerEventHandler {
 
         Player player = event.getCause().first(Player.class).get();
 
+        for (Entity entity : event.getEntities()) {
+            Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, null);
+            Tristate value = player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_ITEM_DROP);
+            if (claim != null) {
+                if (value == Tristate.FALSE) {
+                    event.setCancelled(true);
+                    return;
+                }
+                else if (value == Tristate.TRUE) {
+                    continue;
+                }
+            }
+        }
         // in creative worlds, dropping items is blocked
         if (GriefPrevention.instance.claimModeIsActive(player.getLocation().getExtent().getProperties(), ClaimsMode.Creative)) {
             event.setCancelled(true);
@@ -1098,18 +1111,26 @@ public class PlayerEventHandler {
         }
 
         if (event instanceof InteractEntityEvent.Primary) {
-            if (player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_INTERACT_PRIMARY) == Tristate.FALSE) {
+            Tristate value = player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_INTERACT_PRIMARY);
+            if (value == Tristate.FALSE) {
                 event.setCancelled(true);
             }
+            else if (value == Tristate.TRUE) {
+                return;
+            }
+  
             if (claim != null && claim.allowAccess(player.getWorld(), player) != null) {
                 event.setCancelled(true);
+                return;
             }
-            return;
         }
 
         if (event instanceof InteractEntityEvent.Secondary) {
-            if (player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_INTERACT_SECONDARY) == Tristate.FALSE) {
+            Tristate value = player.getPermissionValue(ImmutableSet.of(claim.getContext()), FlagPermissions.PERMISSION_INTERACT_SECONDARY);
+            if (value == Tristate.FALSE) {
                 event.setCancelled(true);
+            }
+            else if (value == Tristate.TRUE) {
                 return;
             }
         }


### PR DESCRIPTION
This PR will implement numerous flags for GP claims.

**Notes:**

- Flags for `Interact-Primary` and `Interact-Secondary` are working
- Flags for `Item-Drop` and `Block-Break/Place` do not work. Item Drop also fires `CollideBlockEvent` which is cancelled, and Break/Place fire `InteractBlockEvent` which is also canceled.