### PR TITLE
Use API method to send block changes

### DIFF
--- a/src/me/ryanhamshire/griefprevention/Visualization.java
+++ b/src/me/ryanhamshire/griefprevention/Visualization.java
@@ -27,7 +27,6 @@ package me.ryanhamshire.griefprevention;
 
 import me.ryanhamshire.griefprevention.claim.Claim;
 import me.ryanhamshire.griefprevention.task.VisualizationApplicationTask;
-import me.ryanhamshire.griefprevention.util.BlockUtils;
 import net.minecraft.block.Block;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -95,16 +94,16 @@ public class Visualization {
 
             // send real block information for any remaining elements
             for (int i = 0; i < visualization.elements.size(); i++) {
-                Transaction<BlockSnapshot> element = visualization.elements.get(i);
+                BlockSnapshot snapshot = visualization.elements.get(i).getOriginal();
 
                 // check player still in world where visualization exists
                 if (i == 0) {
-                    if (!player.getWorld().equals(element.getOriginal().getLocation().get().getExtent())) {
+                    if (!player.getWorld().equals(snapshot.getLocation().get().getExtent())) {
                         return;
                     }
                 }
 
-                BlockUtils.sendBlockChange(player, element.getOriginal());
+                player.sendBlockChange(snapshot.getPosition(), snapshot.getState());
             }
 
             playerData.currentVisualization = null;

--- a/src/me/ryanhamshire/griefprevention/task/VisualizationApplicationTask.java
+++ b/src/me/ryanhamshire/griefprevention/task/VisualizationApplicationTask.java
@@ -28,10 +28,8 @@ package me.ryanhamshire.griefprevention.task;
 import me.ryanhamshire.griefprevention.GriefPrevention;
 import me.ryanhamshire.griefprevention.PlayerData;
 import me.ryanhamshire.griefprevention.Visualization;
-import me.ryanhamshire.griefprevention.util.BlockUtils;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
-import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.living.player.Player;
 
 import java.util.concurrent.TimeUnit;
@@ -53,13 +51,13 @@ public class VisualizationApplicationTask implements Runnable {
     public void run() {
         // for each element (=block) of the visualization
         for (int i = 0; i < visualization.elements.size(); i++) {
-            Transaction<BlockSnapshot> element = visualization.elements.get(i);
+            BlockSnapshot snapshot = visualization.elements.get(i).getFinal();
 
             // send the player a fake block change event
-            if (!element.getFinal().getLocation().get().getExtent().isLoaded()) {
+            if (!snapshot.getLocation().get().getExtent().isLoaded()) {
                 continue; // cheap distance check
             }
-            BlockUtils.sendBlockChange(player, element.getFinal());
+            player.sendBlockChange(snapshot.getPosition(), snapshot.getState());
         }
 
         // remember the visualization applied to this player for later (so it

--- a/src/me/ryanhamshire/griefprevention/util/BlockUtils.java
+++ b/src/me/ryanhamshire/griefprevention/util/BlockUtils.java
@@ -26,31 +26,12 @@
 package me.ryanhamshire.griefprevention.util;
 
 import com.flowpowered.math.vector.Vector3i;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.network.play.server.S23PacketBlockChange;
-import net.minecraft.util.BlockPos;
-import org.spongepowered.api.block.BlockSnapshot;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
 public class BlockUtils {
 
     private static final String locationStringDelimiter = ";";
-
-    public static void sendBlockChange(Player player, BlockSnapshot snapshot) {
-        EntityPlayerMP playermp = (EntityPlayerMP) player;
-        if (playermp.playerNetServerHandler == null) {
-            return;
-        }
-
-        S23PacketBlockChange packet = new S23PacketBlockChange((net.minecraft.world.World) snapshot.getLocation().get().getExtent(),
-                new BlockPos(snapshot.getPosition().getX(), snapshot.getPosition().getY(), snapshot.getPosition().getZ()));
-
-        packet.blockState = (IBlockState) snapshot.getState();
-        playermp.playerNetServerHandler.sendPacket(packet);
-    }
 
     public static String positionToString(Location<World> location) {
         StringBuilder stringBuilder = new StringBuilder();


### PR DESCRIPTION
This pull request changes the visualisation components to use the SpongeAPI `sendBlockChange` method, rather than the internal implementation.