### PR TITLE
Optionally set chat type in BorderClaimEvent

### DIFF
--- a/src/api/java/me/ryanhamshire/griefprevention/api/event/BorderClaimEvent.java
+++ b/src/api/java/me/ryanhamshire/griefprevention/api/event/BorderClaimEvent.java
@@ -29,6 +29,8 @@ import me.ryanhamshire.griefprevention.api.data.ClaimData;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.entity.TargetEntityEvent;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.chat.ChatType;
+import org.spongepowered.api.text.chat.ChatTypes;
 
 import java.util.Optional;
 
@@ -75,8 +77,9 @@ public interface BorderClaimEvent extends ClaimEvent, TargetEntityEvent {
      * If no message is set, the {@link ClaimData#getGreeting()} will be used.
      * 
      * @param message The message to set
+     * @param chatType The desired chat type, in which the message will be displayed
      */
-    void setEnterMessage(@Nullable Text message);
+    void setEnterMessage(@Nullable Text message, ChatType chatType);
 
     /**
      * Sets the exit message for this event only.
@@ -85,6 +88,53 @@ public interface BorderClaimEvent extends ClaimEvent, TargetEntityEvent {
      * If no message is set, the {@link ClaimData#getFarewell()} will be used.
      * 
      * @param message The message to set
+     * @param chatType The desired chat type, in which the message will be displayed
      */
-    void setExitMessage(@Nullable Text message);
+    void setExitMessage(@Nullable Text message, ChatType chatType);
+
+
+    /**
+     * Sets the exit message for this event only.
+     * The message will send as the chat type {@link ChatTypes#CHAT}
+     *
+     * Note: Setting message to {@code null} will hide the message.
+     * If no message is set, the {@link ClaimData#getFarewell()} will be used.
+     *
+     * For changing the ChatType see {@link BorderClaimEvent#setExitMessage(Text, ChatType)}
+     *
+     * @param message The message to set
+     */
+    default void setExitMessage(@Nullable Text message) {
+        setExitMessage(message, ChatTypes.CHAT);
+    }
+
+
+    /**
+     * Sets the enter message for this event only.
+     * The message will send as the chat type {@link ChatTypes#CHAT}
+     *
+     * Note: Setting message to {@code null} will hide the message.
+     * If no message is set, the {@link ClaimData#getGreeting()} will be used.
+     *
+     * For changing the ChatType see {@link BorderClaimEvent#setEnterMessage(Text, ChatType)}
+     *
+     * @param message The message to set
+     */
+    default void setEnterMessage(@Nullable Text message) {
+        setEnterMessage(message, ChatTypes.CHAT);
+    }
+
+    /**
+     * Returns the chat type for the exit message, if the optional is empty, then {@link ChatTypes#CHAT} will be used
+     *
+     * @return The chat type
+     */
+    Optional<ChatType> getExitMessageChatType();
+
+    /**
+     * Returns the chat type for the enter message, if the optional is empty, then {@link ChatTypes#CHAT} will be used
+     *
+     * @return The chat type
+     */
+    Optional<ChatType> getEnterMessageChatType();
 }

--- a/src/main/java/me/ryanhamshire/griefprevention/event/GPBorderClaimEvent.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/event/GPBorderClaimEvent.java
@@ -29,6 +29,7 @@ import me.ryanhamshire.griefprevention.api.event.BorderClaimEvent;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.chat.ChatType;
 
 import java.util.Optional;
 
@@ -40,6 +41,8 @@ public class GPBorderClaimEvent extends GPClaimEvent implements BorderClaimEvent
     private final Claim exitClaim;
     private Text enterMessage;
     private Text exitMessage;
+    private ChatType enterChatType;
+    private ChatType exitChatType;
 
     public GPBorderClaimEvent(Entity entity, Claim exit, Claim enter, Cause cause) {
         super(enter, cause);
@@ -76,12 +79,26 @@ public class GPBorderClaimEvent extends GPClaimEvent implements BorderClaimEvent
     }
 
     @Override
-    public void setEnterMessage(@Nullable Text message) {
+    public void setEnterMessage(@Nullable Text message, ChatType chatType) {
         this.enterMessage = message;
+        this.enterChatType = chatType;
     }
 
     @Override
-    public void setExitMessage(@Nullable Text message) {
+    public void setExitMessage(@Nullable Text message, ChatType chatType) {
         this.exitMessage = message;
+        this.exitChatType = chatType;
     }
+
+    @Override
+    public Optional<ChatType> getExitMessageChatType() {
+        return Optional.of(exitChatType);
+    }
+
+    @Override
+    public Optional<ChatType> getEnterMessageChatType() {
+        return Optional.of(enterChatType);
+    }
+
+
 }

--- a/src/main/java/me/ryanhamshire/griefprevention/listener/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/listener/EntityEventHandler.java
@@ -84,6 +84,8 @@ import org.spongepowered.api.event.item.inventory.DropItemEvent;
 import org.spongepowered.api.event.world.ExplosionEvent;
 import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.chat.ChatType;
+import org.spongepowered.api.text.chat.ChatTypes;
 import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
@@ -685,12 +687,14 @@ public class EntityEventHandler {
                     playerData.lastClaim = new WeakReference<>(toClaim);
                     Text welcomeMessage = gpEvent.getEnterMessage().orElse(null);
                     if (welcomeMessage != null && !welcomeMessage.equals(Text.of())) {
-                        player.sendMessage(Text.of(enterClanTag != null ? enterClanTag : GriefPreventionPlugin.GP_TEXT, welcomeMessage));
+                        ChatType chatType = gpEvent.getEnterMessageChatType().orElse(ChatTypes.CHAT);
+                        player.sendMessage(chatType, Text.of(enterClanTag != null ? enterClanTag : GriefPreventionPlugin.GP_TEXT, welcomeMessage));
                     }
 
                     Text farewellMessage = gpEvent.getExitMessage().orElse(null);
                     if (farewellMessage != null && !farewellMessage.equals(Text.of())) {
-                        player.sendMessage(Text.of(exitClanTag != null ? exitClanTag : GriefPreventionPlugin.GP_TEXT, farewellMessage));
+                        ChatType chatType = gpEvent.getExitMessageChatType().orElse(ChatTypes.CHAT);
+                        player.sendMessage(chatType, Text.of(exitClanTag != null ? exitClanTag : GriefPreventionPlugin.GP_TEXT, farewellMessage));
                     }
 
                     if (toClaim.isInTown()) {
@@ -749,12 +753,14 @@ public class EntityEventHandler {
                 playerData.lastClaim = new WeakReference<>(toClaim);
                 Text welcomeMessage = gpEvent.getEnterMessage().orElse(null);
                 if (welcomeMessage != null && !welcomeMessage.equals(Text.of())) {
-                    player.sendMessage(Text.of(enterClanTag != null ? enterClanTag : GriefPreventionPlugin.GP_TEXT, welcomeMessage));
+                    ChatType chatType = gpEvent.getEnterMessageChatType().orElse(ChatTypes.CHAT);
+                    player.sendMessage(chatType, Text.of(enterClanTag != null ? enterClanTag : GriefPreventionPlugin.GP_TEXT, welcomeMessage));
                 }
 
                 Text farewellMessage = gpEvent.getExitMessage().orElse(null);
                 if (farewellMessage != null && !farewellMessage.equals(Text.of())) {
-                    player.sendMessage(Text.of(exitClanTag != null ? exitClanTag : GriefPreventionPlugin.GP_TEXT, farewellMessage));
+                    ChatType chatType = gpEvent.getExitMessageChatType().orElse(ChatTypes.CHAT);
+                    player.sendMessage(chatType, Text.of(exitClanTag != null ? exitClanTag : GriefPreventionPlugin.GP_TEXT, farewellMessage));
                 }
 
                 if (toClaim.isInTown()) {


### PR DESCRIPTION
Currently theres no way for thirdparty addons how to display enter/exit messages of the claimed area in the actionbar


..english might be a little bit off in the javadocs.