### PR TITLE
fix claim creation when claim limit was set to 1

### DIFF
--- a/src/main/java/me/ryanhamshire/griefprevention/claim/GPClaim.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/claim/GPClaim.java
@@ -2681,7 +2681,7 @@ public class GPClaim implements Claim {
                 final User user = GriefPreventionPlugin.getOrCreateUser(this.ownerUniqueId);
                 if (this.createLimitRestrictions && !user.hasPermission(GPPermissions.OVERRIDE_CLAIM_LIMIT)) {
                     final Double createClaimLimit = GPOptionHandler.getClaimOptionDouble(user, claim, GPOptions.Type.CLAIM_LIMIT, playerData);
-                    if (createClaimLimit != null && createClaimLimit > 0 && (playerData.getInternalClaims().size() + 1) >= createClaimLimit.intValue()) {
+                    if (createClaimLimit != null && createClaimLimit > 0 && playerData.getInternalClaims().size() >= createClaimLimit.intValue() && playerData.getInternalClaims().size() != 0) {
                         return new GPClaimResult(claim, ClaimResultType.EXCEEDS_MAX_CLAIM_LIMIT);
                     }
                 }

--- a/src/main/java/me/ryanhamshire/griefprevention/listener/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/listener/PlayerEventHandler.java
@@ -2417,8 +2417,8 @@ public class PlayerEventHandler {
                     createClaimLimit = GPOptionHandler.getClaimOptionDouble(player, parentClaim, GPOptions.Type.CLAIM_LIMIT, playerData).intValue();
                 }
 
-                if (createClaimLimit > 0 &&
-                        (playerData.getInternalClaims().size() + 1) >= playerData.optionCreateClaimLimitBasic) {
+                if (createClaimLimit > 0 && playerData.getInternalClaims().size() >= createClaimLimit &&
+                        playerData.getInternalClaims().size() != 0) {
                     GriefPreventionPlugin.sendMessage(player, GriefPreventionPlugin.instance.messageData.claimCreateFailedLimit.toText());
                     GPTimings.PLAYER_HANDLE_SHOVEL_ACTION.stopTimingIfSync();
                     return;


### PR DESCRIPTION
the issue was, when a player had 0 claims so their internal claimcount was 0 and the option CreateClaimLimitBasic was set to 1 they couldnt create claims, because:

`if (createClaimLimit > 0 && (playerData.getInternalClaims().size() + 1) >= playerData.optionCreateClaimLimitBasic) {`

`if (1 > 0 && (0 + 1) >= 1) {`
which is true

now I couldn't just remove the +1 because to set `CreateClaimLimitBasic` to infinite you set 0
`if (1 > 0 && 0 >= 0) {`
still returns true, but should return false

so I added another check, if the internal claim size is 0 it can never exceed the claim limit

I hope that made sense
