### PR TITLE
Check world properties instead of using internals, Fixes #557

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ name=GriefPrevention
 group=me.ryanhamshire
 url=https://github.com/MinecraftPortCentral/GriefPrevention
 organization=MinecraftPortCentral
-version=4.3.0
-apiVersion=7.0.0-SNAPSHOT
+version=4.3.1
+apiVersion=7.1.0-SNAPSHOT
 
 minecraftVersion=1.12.2
 mcpMappings=snapshot_20171007

--- a/src/main/java/me/ryanhamshire/griefprevention/claim/GPClaim.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/claim/GPClaim.java
@@ -94,7 +94,6 @@ import org.spongepowered.api.world.DimensionTypes;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.SpongeImpl;
-import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 
 import java.io.File;
 import java.io.IOException;
@@ -913,7 +912,7 @@ public class GPClaim implements Claim {
             return value.asBoolean();
         }
 
-        return ((IMixinWorldServer) this.world).getActiveConfig().getConfig().getWorld().getPVPEnabled();
+        return this.world.getProperties().isPVPEnabled();
     }
 
     public void setPvpOverride(Tristate value) {


### PR DESCRIPTION
I'm not 100% trustworthy of the apiVersion bump to 7.1.0, but it's also shared by SpongeCommon, and I couldn't get the code to error and not compile, so I'm not sure what else could be lurking.
 

Here is a test build for anyone that wishes to try:

[griefprevention-1.12.2-4.3.1.0.zip](https://github.com/MinecraftPortCentral/GriefPrevention/files/1611685/griefprevention-1.12.2-4.3.1.0.zip)

  
  