### PR TITLE
Various claim expiration option fixes

### DIFF
--- a/src/main/java/me/ryanhamshire/griefprevention/GPPlayerData.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/GPPlayerData.java
@@ -294,7 +294,8 @@ public class GPPlayerData implements PlayerData {
             this.optionClaimCreateMode = PlayerUtils.getOptionIntValue(subject, GPOptions.CLAIM_CREATE_MODE, this.optionClaimCreateMode);
             this.optionClaimExpirationChest = PlayerUtils.getOptionIntValue(subject, GPOptions.CLAIM_EXPIRATION_CHEST, this.optionClaimExpirationChest);
             this.optionClaimExpirationBasic = PlayerUtils.getOptionIntValue(subject, GPOptions.CLAIM_EXPIRATION_BASIC, this.optionClaimExpirationBasic);
-            this.optionClaimExpirationTown = PlayerUtils.getOptionIntValue(subject, GPOptions.TAX_EXPIRATION_TOWN, this.optionClaimExpirationTown);
+            this.optionClaimExpirationTown = PlayerUtils.getOptionIntValue(subject, GPOptions.CLAIM_EXPIRATION_TOWN, this.optionClaimExpirationTown);
+            this.optionClaimExpirationSubdivision = PlayerUtils.getOptionIntValue(subject, GPOptions.CLAIM_EXPIRATION_SUBDIVISION, this.optionClaimExpirationSubdivision);
             this.optionTaxExpirationBasic = PlayerUtils.getOptionIntValue(subject, GPOptions.TAX_EXPIRATION_BASIC, this.optionTaxExpirationBasic);
             this.optionTaxExpirationSubdivision = PlayerUtils.getOptionIntValue(subject, GPOptions.TAX_EXPIRATION_BASIC, this.optionTaxExpirationSubdivision);
             this.optionTaxExpirationTown = PlayerUtils.getOptionIntValue(subject, GPOptions.TAX_EXPIRATION_BASIC, this.optionTaxExpirationTown);

--- a/src/main/java/me/ryanhamshire/griefprevention/command/CommandPlayerInfo.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/command/CommandPlayerInfo.java
@@ -104,27 +104,30 @@ public class CommandPlayerInfo implements CommandExecutor {
             claimSizeLimit = Text.of(TextColors.GRAY, playerData.optionMaxClaimSizeBasicX + "," + playerData.optionMaxClaimSizeBasicY + "," + playerData.optionMaxClaimSizeBasicZ);
         }
 
-        Text townTaxRate = Text.of(
-                TextColors.GRAY, "TOWN", TextColors.WHITE, " : ", TextColors.GREEN, playerData.optionTaxRateTown, 
-                TextColors.GRAY, " BASIC", TextColors.WHITE, " : ", TextColors.GREEN, playerData.optionTaxRateTownBasic, 
-                TextColors.GRAY, " SUB", TextColors.WHITE, " : ", TextColors.GREEN, playerData.optionTaxRateTownSubdivision);
-        Text claimTaxRate = Text.of(
-                TextColors.GRAY, "BASIC", TextColors.WHITE, " : ", TextColors.GREEN, playerData.optionTaxRateBasic, 
-                TextColors.GRAY, " SUB", TextColors.WHITE, " : ", TextColors.GREEN, playerData.optionTaxRateSubdivision);
-        Text currentTaxRateText = Text.of(TextColors.YELLOW, "Current Claim Tax Rate", TextColors.WHITE, " : ", TextColors.RED, "N/A");
+        final Text WHITE_SEMI_COLON = Text.of(TextColors.WHITE, " : ");
+        final Text claimExpiration = Text.of(
+                TextColors.GRAY, "TOWN", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionClaimExpirationTown,
+                TextColors.GRAY, " BASIC", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionClaimExpirationBasic,
+                TextColors.GRAY, " SUB", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionClaimExpirationSubdivision,
+                TextColors.GRAY, " CHEST", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionClaimExpirationChest);
+        final Text townTaxRate = Text.of(
+                TextColors.GRAY, "TOWN", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionTaxRateTown,
+                TextColors.GRAY, " BASIC", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionTaxRateTownBasic,
+                TextColors.GRAY, " SUB", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionTaxRateTownSubdivision);
+        final Text claimTaxRate = Text.of(
+                TextColors.GRAY, "BASIC", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionTaxRateBasic,
+                TextColors.GRAY, " SUB", WHITE_SEMI_COLON, TextColors.GREEN, playerData.optionTaxRateSubdivision);
+        Text currentTaxRateText = Text.of(TextColors.YELLOW, "Current Claim Tax Rate", WHITE_SEMI_COLON, TextColors.RED, "N/A");
         if (src instanceof Player) {
             Player player = (Player) src;
             if (player.getUniqueId().equals(user.getUniqueId())) {
                 final GPClaim claim = GriefPreventionPlugin.instance.dataStore.getClaimAt(player.getLocation());
                 if (claim != null && !claim.isWilderness()) {
                     final double playerTaxRate = GPOptionHandler.getClaimOptionDouble(user, claim, GPOptions.Type.TAX_RATE, playerData);
-                    currentTaxRateText = Text.of(
-                            TextColors.YELLOW, "Current Claim Tax Rate", TextColors.WHITE, " : ",
-                            TextColors.GREEN, playerTaxRate);
+                    currentTaxRateText = Text.of(TextColors.YELLOW, "Current Claim Tax Rate", WHITE_SEMI_COLON, TextColors.GREEN, playerTaxRate);
                 }
             }
         }
-        final Text WHITE_SEMI_COLON = Text.of(TextColors.WHITE, " : ");
         final double claimableChunks = GriefPreventionPlugin.CLAIM_BLOCK_SYSTEM == ClaimBlockSystem.VOLUME ? (playerData.getRemainingClaimBlocks() / 65536.0) : (playerData.getRemainingClaimBlocks() / 256.0);
         final Text uuidText = Text.of(TextColors.YELLOW, "UUID", WHITE_SEMI_COLON, TextColors.GRAY, user.getUniqueId());
         final Text worldText = Text.of(TextColors.YELLOW, "World", WHITE_SEMI_COLON, TextColors.GRAY, worldProperties.getWorldName());
@@ -137,6 +140,7 @@ public class CommandPlayerInfo implements CommandExecutor {
         final Text minLevelText = Text.of(TextColors.YELLOW, "Minimum Claim Level", WHITE_SEMI_COLON, TextColors.GREEN, playerData.getMinClaimLevel());
         final Text maxLevelText = Text.of(TextColors.YELLOW, "Maximum Claim Level", WHITE_SEMI_COLON, TextColors.GREEN, playerData.getMaxClaimLevel());
         final Text abandonRatioText = Text.of(TextColors.YELLOW, "Abandoned Return Ratio", WHITE_SEMI_COLON, TextColors.GREEN, playerData.getAbandonedReturnRatio());
+        final Text claimExpirationText = Text.of(TextColors.YELLOW, "Claim Expiration", WHITE_SEMI_COLON, TextColors.GREEN, claimExpiration);
         final Text globalTownTaxText = Text.of(TextColors.YELLOW, "Global Town Tax Rate", WHITE_SEMI_COLON, TextColors.GREEN, townTaxRate);
         final Text globalClaimTaxText = Text.of(TextColors.YELLOW, "Global Claim Tax Rate", WHITE_SEMI_COLON, TextColors.GREEN, claimTaxRate);
         final Text totalTaxText = Text.of(TextColors.YELLOW, "Total Tax", WHITE_SEMI_COLON, TextColors.GREEN, playerData.getTotalTax());
@@ -156,6 +160,7 @@ public class CommandPlayerInfo implements CommandExecutor {
         claimsTextList.add(minLevelText);
         claimsTextList.add(maxLevelText);
         claimsTextList.add(abandonRatioText);
+        claimsTextList.add(claimExpirationText);
         if (GriefPreventionPlugin.getGlobalConfig().getConfig().claim.bankTaxSystem) {
             claimsTextList.add(currentTaxRateText);
             claimsTextList.add(globalTownTaxText);
@@ -174,14 +179,11 @@ public class CommandPlayerInfo implements CommandExecutor {
                 // ignore
             }
             if (lastActive != null) {
-                claimsTextList.add(Text.of(TextColors.YELLOW, "Last Active", TextColors.WHITE, " : ", TextColors.GRAY, lastActive));
+                claimsTextList.add(Text.of(TextColors.YELLOW, "Last Active", WHITE_SEMI_COLON, TextColors.GRAY, lastActive));
             }
         }
 
-        PaginationService paginationService = Sponge.getServiceManager().provide(PaginationService.class).get();
-        PaginationList.Builder paginationBuilder = paginationService.builder()
-                .title(Text.of(TextColors.AQUA, "Player Info")).padding(Text.of(TextStyles.STRIKETHROUGH, "-")).contents(claimsTextList);
-        paginationBuilder.sendTo(src);
+        PaginationList.builder().title(Text.of(TextColors.AQUA, "Player Info")).padding(Text.of(TextStyles.STRIKETHROUGH, "-")).contents(claimsTextList).sendTo(src);
 
         return CommandResult.success();
     }

--- a/src/main/java/me/ryanhamshire/griefprevention/configuration/category/ClaimCategory.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/configuration/category/ClaimCategory.java
@@ -37,18 +37,18 @@ public class ClaimCategory extends ConfigCategory {
     public List<String> accessTrustCommands = new ArrayList<>();
     @Setting(value = "auto-claim-radius", comment = "Radius used for auto-created claims. Set to -1 to disable.")
     public int claimRadius = 4;
-    @Setting(value = "cleanup-task-interval", comment = "The interval in minutes for restoring blocks in an expired claim. Set to 0 to disable. Note: This only supports vanilla blocks. Use with caution if using custom biomes.")
+    @Setting(value = "cleanup-task-interval", comment = "The interval in minutes for attempting to remove expired claims. Set to 0 to disable.")
     public int cleanupTaskInterval = 5;
     @Setting(value = "deliver-manuals", comment = "Send players manuals on claim creation.")
     public boolean deliverManuals = false;
-    @Setting(value = "auto-nature-restore", comment = "Whether survival claims will be automatically restored to nature when auto-deleted.")
+    @Setting(value = "auto-nature-restore", comment = "Whether survival claims will be automatically restored to nature when auto-deleted. "
+            + "Note: This only supports vanilla blocks. Use with caution if using custom biomes.")
     public boolean claimAutoNatureRestore = false;
     @Setting(value = "investigation-tool", comment = "The item used to investigate claims with a right-click.")
     public String investigationTool = "minecraft:stick";
     @Setting(value = "modification-tool", comment = "The item used to create/resize claims with a right click.")
     public String modificationTool = "minecraft:golden_shovel";
-    @Setting(value = "claims-mode",
-            comment = "The mode used when creating claims. (0 = Disabled, 1 = Survival, 2 = Creative)")
+    @Setting(value = "claims-mode", comment = "The mode used when creating claims. (0 = Disabled, 1 = Survival, 2 = Creative)")
     public int claimMode = 1;
     @Setting(value = "bank-tax-system", comment = "Whether to enable the bank/tax system for claims. Set to true to enable.")
     public boolean bankTaxSystem = false;


### PR DESCRIPTION
- Claim Expiration task now uses configured options instead of defaults
- Implemented previously unimplemented Subdivision & Town claim expiration options
- Claim expiration options now show on `/playerdata`
- Clarified cleanup-task-interval & auto-nature-restore config comments

![image](https://user-images.githubusercontent.com/3623122/36015702-462d0e98-0d35-11e8-97e0-e62e5dd49cb7.png)