### PR TITLE
Fix claimsell trust check & change claimsell permission. 

### DIFF
--- a/src/main/java/me/ryanhamshire/griefprevention/GriefPreventionPlugin.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/GriefPreventionPlugin.java
@@ -1094,7 +1094,7 @@ public class GriefPreventionPlugin {
 
         Sponge.getCommandManager().register(this, CommandSpec.builder()
                 .description(Text.of("Puts your claim up for sale. Use /claimsell amount. Requires an economy plugin"))
-                .permission(GPPermissions.COMMAND_SELL_CLAIM_BLOCKS)
+                .permission(GPPermissions.COMMAND_CLAIM_SELL)
                 .arguments(GenericArguments.firstParsing(doubleNum(Text.of("price")), string(Text.of("cancel"))))
                 .executor(new CommandClaimSell())
                 .build(), "claimsell");

--- a/src/main/java/me/ryanhamshire/griefprevention/command/CommandClaimSell.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/command/CommandClaimSell.java
@@ -71,7 +71,7 @@ public class CommandClaimSell implements CommandExecutor {
             return CommandResult.success();
         }
 
-        if (!playerData.canIgnoreClaim((GPClaim) claim) && !src.hasPermission(GPPermissions.COMMAND_CLAIM_SELL)) {
+        if (!playerData.canIgnoreClaim((GPClaim) claim) && !src.hasPermission(GPPermissions.COMMAND_CLAIM_SELL) || !player.getUniqueId().equals(claim.getOwnerUniqueId())) {
             GriefPreventionPlugin.sendMessage(player, GriefPreventionPlugin.instance.messageData.permissionClaimSale.toText());
             return CommandResult.success();
         }


### PR DESCRIPTION
Fixes #611
This also changes the permission for the claimsell command.
Currently it's the same permission for /claimsell as it is for /sellclaimblocks. They are different commands, different usage, why use the same permission?
Tested on local server 1.12.2 and confirmed that fix worked.

PS: sorry for the '8' commits lol, quite new to Git and messed a few things up..