### PR TITLE
Add BStats support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,11 @@ repositories {
     }
     maven {
         name = 'worldedit'
-        url = 'http://maven.sk89q.com/artifactory/repo'		
+        url = 'http://maven.sk89q.com/artifactory/repo'
+    }
+    maven {
+        name = 'bstats'
+        url = 'http://repo.bstats.org/content/repositories/releases/'
     }
 }
 
@@ -79,6 +83,7 @@ dependencies {
     compileOnly "com.googlecode.json-simple:json-simple:1.1"
     compile "com.squareup.okhttp3:okhttp:3.9.1"
     compile "com.squareup.okio:okio:1.13.0"
+    compile "org.bstats:bstats-sponge:1.2"
     compileOnly "io.github.nucleuspowered:nucleus-api:1.2.0-PR5-S7.0"
     compileOnly "nl.riebie:mcclans-api:1.3"
 }
@@ -131,6 +136,7 @@ shadowJar {
     dependencies {
         include dependency("com.squareup.okhttp3:okhttp:3.9.1")
         include dependency("com.squareup.okio:okio:1.13.0")
+        include dependency("org.bstats:bstats-sponge:1.2")
     }
 
     exclude "dummyThing"

--- a/src/main/java/me/ryanhamshire/griefprevention/GriefPreventionPlugin.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/GriefPreventionPlugin.java
@@ -147,6 +147,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.LocaleUtils;
+import org.bstats.sponge.Metrics;
 import org.slf4j.Logger;
 import org.spongepowered.api.Platform.Component;
 import org.spongepowered.api.Sponge;
@@ -232,6 +233,7 @@ public class GriefPreventionPlugin {
     public static String SPONGE_VERSION = "unknown";
     @Inject public PluginContainer pluginContainer;
     @Inject private Logger logger;
+    @Inject private Metrics metrics;
     @Inject @ConfigDir(sharedRoot = false)
     private Path configPath;
     public MessageStorage messageStorage;
@@ -830,7 +832,7 @@ public class GriefPreventionPlugin {
         final int migration2dRate = GriefPreventionPlugin.getGlobalConfig().getConfig().playerdata.migrateAreaRate;
         final int migration3dRate = GriefPreventionPlugin.getGlobalConfig().getConfig().playerdata.migrateVolumeRate;
         boolean migrate = false;
-        if (resetMigration || resetClaimData || (migration2dRate > -1 && GriefPreventionPlugin.CLAIM_BLOCK_SYSTEM == ClaimBlockSystem.AREA) 
+        if (resetMigration || resetClaimData || (migration2dRate > -1 && GriefPreventionPlugin.CLAIM_BLOCK_SYSTEM == ClaimBlockSystem.AREA)
                 || (migration3dRate > -1 && GriefPreventionPlugin.CLAIM_BLOCK_SYSTEM == ClaimBlockSystem.VOLUME)) {
             migrate = true;
         }
@@ -1169,7 +1171,7 @@ public class GriefPreventionPlugin {
         Sponge.getCommandManager().register(this, CommandSpec.builder()
                 .description(Text.of("Sets a permission on a group with a claim context"))
                 .permission(GPPermissions.COMMAND_CLAIM_PERMISSION_GROUP)
-                .arguments(string(Text.of("group")), 
+                .arguments(string(Text.of("group")),
                         optional(GenericArguments.seq(string(Text.of("permission")), string(Text.of("value")))))
                 .executor(new CommandClaimPermissionGroup())
                 .build(), "claimpermissiongroup", "cpg");


### PR DESCRIPTION
This commit adds support for reporting usage information to [bStats](https://bstats.org), a free plugin metrics site.

@bloodmc You'll need to sign up for an account [here](https://bstats.org/register) if you want to use this.

Server owner that don't want metrics to reported can op-out via the generated config file in `config/bStats`.