### PR TITLE
Allow GriefPrevention to be loaded in a de-obfuscated developer environment

### DIFF
--- a/src/main/java/me/ryanhamshire/griefprevention/GriefPreventionPlugin.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/GriefPreventionPlugin.java
@@ -402,6 +402,10 @@ public class GriefPreventionPlugin {
 
     private boolean validateSpongeVersion() {
         if (Sponge.getPlatform().getContainer(Component.IMPLEMENTATION).getName().equals("SpongeForge")) {
+            if (SpongeImplHooks.isDeobfuscatedEnvironment()) {
+                this.logger.info("De-obfuscated environment detected! Use at your own risk!");
+                return true;
+            }
             if (Sponge.getPlatform().getContainer(Component.IMPLEMENTATION).getVersion().isPresent()) {
                 try {
                     SPONGE_VERSION = Sponge.getPlatform().getContainer(Component.IMPLEMENTATION).getVersion().get();
@@ -424,7 +428,7 @@ public class GriefPreventionPlugin {
 
     @Listener(order = Order.LAST)
     public void onPreInit(GamePreInitializationEvent event) {
-        if (!validateSpongeVersion() || Sponge.getPlatform().getType().isClient()) {
+        if (!validateSpongeVersion() || (Sponge.getPlatform().getType().isClient() && !SpongeImplHooks.isDeobfuscatedEnvironment())) {
             return;
         }
 


### PR DESCRIPTION
Commit is self-explanatory.  Allows Grief Prevention to load within a developers de-obfuscated environment for plugin development purposes.

Signed-off-by: Dockter <dockter@almuramc.com>